### PR TITLE
Upgrading to python 3.10

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,7 +11,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-        - '3.9'
         - '3.10'
         - '3.11'
         - '3.12'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,19 +12,15 @@ readme = "README.md"
 authors = [{name = "Mazin Lab contributors"}]
 license = { text = "BSD-2-clause" }
 
-requires-python = "~=3.9"
+requires-python = "~=3.10"
 dependencies = [
-  "setuptools>=72.2.0",
-
-  "numpy>=1.24", # We pin this because we build a C extension, when you update this also update the build system depend
-
-  "astropy>=5.0",
-  "astroplan>=0.10",
-
-  "ruamel.yaml>0.18",
-  "pyyaml>=6.0.2",
-
-  "multiprocessing_logging"
+    "setuptools>=72.2.0",
+    "numpy>=1.24", # We pin this because we build a C extension, when you update this also update the build system depend
+    "astropy>=5.0",
+    "astroplan>=0.10",
+    "ruamel.yaml>0.18",
+    "pyyaml>=6.0.2",
+    "multiprocessing_logging",
 ]
 
 [build-system]


### PR DESCRIPTION
Upgrading pyproject.toml and main.yaml to 3.10 instead of 3.9 to enable compatibility with newer package versions